### PR TITLE
replaced ravel with np.asarray(y0).reshape(-1)

### DIFF
--- a/odeintw/_odeintw.py
+++ b/odeintw/_odeintw.py
@@ -164,7 +164,7 @@ def odeintw(func, y0, t, **kwargs):
 
         # Flatten y0, and create a wrapper for func that can be used
         # by odeint.
-        y0 = y0.ravel()
+        y0 = np.asarray(y0).reshape(-1)
 
         if tfirst:
             def vecfunc(t, y, *args):


### PR DESCRIPTION
I opened an issue [here](https://github.com/WarrenWeckesser/odeintw/issues/8) and this is a fix for it. It should basically do the same thing but will return an array for odeint to use not a matrix with 1 row.